### PR TITLE
Use `which` to detect paths, rather than assume /usr/bin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     ],
     "contributors": [
         "Terin Stock <terin@terinstock.com>",
-        "安坚实 <anjianshi@gmail.com>"
+        "安坚实 <anjianshi@gmail.com>",
+        "John Vilk <jvilk@cs.umass.edu>"
     ],
     "repository": {
         "type": "git",
@@ -80,5 +81,6 @@
         "phantomjs": "1.9.18"
     },
     "dependencies": {
+        "which": "~1.2.0"
     }
 }


### PR DESCRIPTION
Uses the well-tested `which` module to detect program paths when all else fails. Previously, `karma-detect-browsers` would check `/usr/bin` for the executable, which is not robust to scenarios where browsers are installed elsewhere. For example, Travis-CI installs browsers to `/usr/local/bin`.