### PR TITLE
Add support for Edge on Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ module.exports = function(config) {
 
     plugins: [
       'karma-chrome-launcher',
+      'karma-edge-launcher',
       'karma-firefox-launcher',
       'karma-ie-launcher',
       'karma-safari-launcher',
@@ -99,6 +100,7 @@ module.exports = function(config) {
 
     plugins: [
       'karma-chrome-launcher',
+      'karma-edge-launcher',
       'karma-firefox-launcher',
       'karma-ie-launcher',
       'karma-safari-launcher',

--- a/browsers/Edge.js
+++ b/browsers/Edge.js
@@ -1,0 +1,9 @@
+var resolve = require('resolve');
+
+module.exports = {
+    name: 'Edge',
+    DEFAULT_CMD: {
+        win32: [resolve.sync('edge-launcher/Win32/MicrosoftEdgeLauncher.exe')]
+    },
+    ENV_CMD: 'EDGE_BIN'
+};

--- a/browsers/index.js
+++ b/browsers/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     chrome: require('./Chrome.js'),
     chromeCanary: require('./ChromeCanary.js'),
+    edge: require('./Edge.js'),
     firefox: require('./Firefox.js'),
     firefoxAurora: require('./FirefoxAurora.js'),
     firefoxNightly: require('./FirefoxNightly.js'),

--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -61,6 +61,7 @@ module.exports = function (config) {
         plugins: [
             'karma-jasmine',
             'karma-chrome-launcher',
+            'karma-edge-launcher',
             'karma-firefox-launcher',
             'karma-ie-launcher',
             'karma-safari-launcher',

--- a/index.js
+++ b/index.js
@@ -29,12 +29,11 @@ var DetectBrowsers = function (config, logger) {
                 try {
                     var browserLocated = fs.existsSync(browserPaths[y]) || process.env[browser.ENV_CMD] || which.sync(browserPaths[y]);
 
-                    // ignore Edge on operating systems other than Windows 10
+                    // don't use Edge on operating systems other than Windows 10
                     // (the launcher would be found, but would fail to run)
-                    var browserIgnored = browser.name === 'Edge' &&
-                                         (!process.platform === 'win32' || !/^1\d/.test(os.release()));
+                    var useBrowser = browser.name !== 'Edge' || process.platform === 'win32' && /^1\d/.test(os.release());
 
-                    if (browserLocated && !browserIgnored) {
+                    if (browserLocated && useBrowser) {
                         // add browser when found in file system or when env variable is set
                         result.push(browser.name);
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var DetectBrowsers = function (config, logger) {
     var fs = require('fs'),
+        os = require('os'),
         which = require('which'),
         browsers = require('./browsers'),
         log = logger.create('framework.detect-browsers');
@@ -26,7 +27,14 @@ var DetectBrowsers = function (config, logger) {
             // iterate over all browser paths
             for (y = 0; y < paths; y++) {
                 try {
-                    if (fs.existsSync(browserPaths[y]) || process.env[browser.ENV_CMD] || which.sync(browserPaths[y])) {
+                    var browserLocated = fs.existsSync(browserPaths[y]) || process.env[browser.ENV_CMD] || which.sync(browserPaths[y]);
+
+                    // ignore Edge on operating systems other than Windows 10
+                    // (the launcher would be found, but would fail to run)
+                    var browserIgnored = browser.name === 'Edge' &&
+                                         (!process.platform === 'win32' || !/^1\d/.test(os.release()));
+
+                    if (browserLocated && !browserIgnored) {
                         // add browser when found in file system or when env variable is set
                         result.push(browser.name);
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "jasmine-core": "^2.4.1",
         "karma": "^0.13.22",
         "karma-chrome-launcher": "*",
+        "karma-edge-launcher": "*",
         "karma-firefox-launcher": "*",
         "karma-ie-launcher": "*",
         "karma-jasmine": "^0.3.8",
@@ -85,6 +86,7 @@
         "phantomjs-prebuilt": "2.1.7"
     },
     "dependencies": {
+        "resolve": "^1.1.7",
         "which": "^1.2.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "Safari Tech Preview",
         "SafariTechPreview",
         "IE",
+        "Edge",
         "Chrome",
         "Chrome Canary",
         "Firefox",


### PR DESCRIPTION
Fixes #13. This uses my [karma-edge-launcher](https://github.com/nickmccurdy/karma-edge-launcher) plugin. Since Edge is a UWP app and not a traditional exe file, this locates a launcher ([edge-launcher](https://github.com/MicrosoftEdge/edge-launcher)) instead of the browser itself.

## Notes
- Because the launcher would be found on operating systems other than Windows 10 (since it's included in `node_modules`), I had to add some extra code to `index.js` to ignore Edge on older versions of Windows and other operating systems.
- Windows Server doesn't include Edge yet (but they're working on it in technical previews). This could be a problem if the plugin is run on Windows Server 2016 and `os.release()` reports `10.x`. It's also worth noting that AppVeyor is using Windows Server.
- karma-edge-launcher is still in development.