### PR TITLE
Make Edge.js always return a browser object

### DIFF
--- a/browsers/Edge.js
+++ b/browsers/Edge.js
@@ -4,7 +4,7 @@ var CMD;
 try {
     CMD = resolve.sync('edge-launcher/Win32/MicrosoftEdgeLauncher.exe');
 } catch (e) {
-    return '';
+    CMD = '';
 }
 
 module.exports = {


### PR DESCRIPTION
This makes it line up with the other browser files and fixes #17.