### PR TITLE
Update Edge detection to follow bug fixes in karma-edge-launcher

### DIFF
--- a/browsers/Edge.js
+++ b/browsers/Edge.js
@@ -1,8 +1,7 @@
-var resolve = require('resolve');
 var CMD;
 
 try {
-    CMD = resolve.sync('edge-launcher/Win32/MicrosoftEdgeLauncher.exe');
+    CMD = require.resolve('edge-launcher/Win32/MicrosoftEdgeLauncher.exe');
 } catch (e) {
     CMD = '';
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
         "phantomjs-prebuilt": "2.1.7"
     },
     "dependencies": {
-        "resolve": "^1.1.7",
         "which": "^1.2.4"
     }
 }


### PR DESCRIPTION
When I originally submitted a [pull request for karma-edge-launcher support](https://github.com/litixsoft/karma-detect-browsers/pull/15), the launcher was using the `resolve` package on npm. I recently learned that the package is very buggy, and is mostly untested on all versions of node that are currently supported. Now that karma-edge-launcher has internally migrated away from this buggy dependency, I would like to do the same for this project to ensure consistent behavior with the launcher and prevent bugs that wouldn't be present in Node's `require.resolve()` method.

## Why keep try/catch?
Even though Node's built in `require.resolve()` should cause less errors to be thrown, the try/catch is still useful for people that update this package but forget to add karma-edge-launcher as a dependency (preventing bugs like #16, #17, and #19).