### PR TITLE
Update edge launcher binary path

### DIFF
--- a/browsers/Edge.js
+++ b/browsers/Edge.js
@@ -1,7 +1,7 @@
 var CMD;
 
 try {
-    CMD = require.resolve('edge-launcher/Win32/MicrosoftEdgeLauncher.exe');
+    CMD = require.resolve('edge-launcher/dist/x86/MicrosoftEdgeLauncher.exe');
 } catch (e) {
     CMD = '';
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "安坚实 <anjianshi@gmail.com>",
         "John Vilk <jvilk@cs.umass.edu>",
         "Marcos Caceres <marcos@marcosc.com>",
-        "Nick McCurdy <thenickperson@gmail.com>"
+        "Nick McCurdy <nick@nickmccurdy.com>"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
[edge-launcher](https://github.com/MicrosoftEdge/edge-launcher) moved its binary recently. I updated the path in karma-edge-launcher, but this package will break without the same update.