### PR TITLE
Split Chrome and Chromium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ node_js:
   - '5'
   - 'stable'
 before_script:
-  - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - npm install -g grunt-cli

--- a/browsers/Chrome.js
+++ b/browsers/Chrome.js
@@ -1,9 +1,7 @@
 module.exports = {
     name: 'Chrome',
     DEFAULT_CMD: {
-        // Try chromium-browser before chromium to avoid conflict with the legacy
-        // chromium-bsu package previously known as 'chromium' in Debian and Ubuntu.
-        linux: ['chromium-browser', 'chromium', 'google-chrome', 'google-chrome-stable'],
+        linux: ['google-chrome', 'google-chrome-stable'],
         darwin: ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
         win32: [
             process.env.LOCALAPPDATA + '\\Google\\Chrome\\Application\\chrome.exe',

--- a/browsers/Chromium.js
+++ b/browsers/Chromium.js
@@ -1,0 +1,11 @@
+module.exports = {
+    name: 'Chromium',
+    DEFAULT_CMD: {
+        // Try chromium-browser before chromium to avoid conflict with the legacy
+        // chromium-bsu package previously known as 'chromium' in Debian and Ubuntu.
+        linux: ['chromium-browser', 'chromium'],
+        darwin: [],
+        win32: []
+    },
+    ENV_CMD: 'CHROMIUM_BIN'
+};

--- a/browsers/index.js
+++ b/browsers/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     chrome: require('./Chrome.js'),
+    chromium: require('./Chromium.js'),
     chromeCanary: require('./ChromeCanary.js'),
     edge: require('./Edge.js'),
     firefox: require('./Firefox.js'),

--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function (config) {
         // level of logging
         // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
         // CLI --log-level debug
-        logLevel: config.LOG_INFO,
+        logLevel: config.LOG_DEBUG,
 
         // enable / disable watching file and executing tests whenever any file changes
         // CLI --auto-watch --no-auto-watch

--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -37,6 +37,7 @@ module.exports = function (config) {
 
         // Start these browsers, currently available:
         // - Chrome
+        // - Chromium
         // - ChromeCanary
         // - Firefox
         // - Opera


### PR DESCRIPTION
Related to #22 

This was supposed to be easy, a simple split, however now travis says Chromium can't connect even though Chrome works fine with `CHROME_BIN=chromium-browser`. Logs are [here](https://travis-ci.org/LoveIsGrief/karma-detect-browsers/jobs/222597188)

I'd be happy to investigate further, but I simply cannot reproduce the issue on my machine. Even forced on a VM. Suggestions are welcome.