### PR TITLE
Support for headless mode, in browsers that support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ module.exports = function(config) {
       // enable/disable phantomjs support, default is true
       usePhantomJS: true,
 
+      // use headless mode, for browsers that support it, default is false
+      preferHeadless: true,
+
       // post processing of browsers list
       // here you can edit the list of browsers used by karma
       postDetection: function(availableBrowser) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 'use strict';
 
+var headlessBrowsers = [
+    'Chrome',
+    'Chromium',
+    'ChromeCanary',
+    'Firefox',
+    'FirefoxDeveloper',
+    'FirefoxAurora',
+    'FirefoxNightly',
+];
+
 var DetectBrowsers = function (config, logger) {
     var fs = require('fs'),
         os = require('os'),
@@ -75,6 +85,11 @@ var DetectBrowsers = function (config, logger) {
         // check for PhantomJS option
         if (config.detectBrowsers.usePhantomJS !== false) {
             availableBrowser.push('PhantomJS');
+        }
+        if (config.detectBrowsers.preferHeadless) {
+            availableBrowser = availableBrowser.map(function (browser) {
+                return headlessBrowsers.indexOf(browser) >= 0 ? browser + 'Headless' : browser;
+            });
         }
 
         log.info('The following browsers were detected on your system:', availableBrowser);


### PR DESCRIPTION
This change adds a `preferHeadless` option, which enable headless mode for browsers that support it.