### PR TITLE
Splitting Chromium out of Chrome and adding support for headless mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ node_js:
   - '8'
   - 'stable'
 before_script:
-  - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,17 +27,26 @@ if(process.env.TRAVIS) {
         var config = karmaConfig[keys[i]];
 
         config.customLaunchers = {
-            Chrome_travis_ci: {
-                base: 'Chrome',
+            ChromeHeadless_travis_ci: {
+                base: 'ChromeHeadless',
+                flags: ['--no-sandbox']
+            },
+            ChromiumHeadless_travis_ci: {
+                base: 'ChromiumHeadless',
                 flags: ['--no-sandbox']
             }
         };
 
         config.detectBrowsers = config.detectBrowsers || {};
+        config.detectBrowsers.preferHeadless = true;
         config.detectBrowsers.postDetection = function(browsers) {
-            var index = browsers.indexOf('Chrome');
-            if(index !== -1) {
-                browsers[index] = 'Chrome_travis_ci';
+            var chromeHeadlessIndex = browsers.indexOf('ChromeHeadless');
+            if(chromeHeadlessIndex !== -1) {
+                browsers[chromeHeadlessIndex] = 'ChromeHeadless_travis_ci';
+            }
+            var chromiumHeadlessIndex = browsers.indexOf('ChromiumHeadless');
+            if(chromiumHeadlessIndex !== -1) {
+                browsers[chromiumHeadlessIndex] = 'ChromiumHeadless_travis_ci';
             }
             return browsers;
         };

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ module.exports = function(config) {
       // enable/disable phantomjs support, default is true
       usePhantomJS: true,
 
+      // use headless mode, for browsers that support it, default is false
+      preferHeadless: true,
+
       // post processing of browsers list
       // here you can edit the list of browsers used by karma
       postDetection: function(availableBrowser) {

--- a/browsers/Chrome.js
+++ b/browsers/Chrome.js
@@ -1,9 +1,7 @@
 module.exports = {
     name: 'Chrome',
     DEFAULT_CMD: {
-        // Try chromium-browser before chromium to avoid conflict with the legacy
-        // chromium-bsu package previously known as 'chromium' in Debian and Ubuntu.
-        linux: ['chromium-browser', 'chromium', 'google-chrome', 'google-chrome-stable'],
+        linux: ['google-chrome', 'google-chrome-stable'],
         darwin: ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
         win32: [
             process.env.LOCALAPPDATA + '\\Google\\Chrome\\Application\\chrome.exe',

--- a/browsers/Chromium.js
+++ b/browsers/Chromium.js
@@ -1,0 +1,18 @@
+module.exports = {
+    name: 'Chromium',
+    DEFAULT_CMD: {
+        linux: [
+            // Try chromium-browser before chromium to avoid conflict with the legacy
+            // chromium-bsu package previously known as 'chromium' in Debian and Ubuntu.
+            'chromium-browser',
+            'chromium',
+        ],
+        darwin: [
+            '/Applications/Google Chrome.app/Contents/MacOS/Chromium',
+        ],
+        win32: [
+            process.env['ProgramFiles(x86)'] + '\\Chromium\\Application\\chrome.exe',
+        ],
+    },
+    ENV_CMD: 'CHROMIUM_BIN'
+};

--- a/browsers/index.js
+++ b/browsers/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     chrome: require('./Chrome.js'),
     chromeCanary: require('./ChromeCanary.js'),
+    chromium: require('./Chromium.js'),
     edge: require('./Edge.js'),
     firefox: require('./Firefox.js'),
     firefoxAurora: require('./FirefoxAurora.js'),

--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
         // use dots reporter, as travis terminal does not support escaping sequences
         // possible values: 'dots', 'progress'
         // CLI --reporters progress
-        reporters: ['progress'],
+        reporters: [process.env.TRAVIS ? 'dots' : 'progress'],
 
         // web server port
         // CLI --port 9876
@@ -44,7 +44,7 @@ module.exports = function (config) {
         // - PhantomJS
         // - IE (only Windows)
         // CLI --browsers Chrome,Firefox,Safari
-        browsers: [process.env.TRAVIS ? 'Firefox' : 'Chrome'],
+        browsers: [process.env.TRAVIS ? 'ChromiumHeadless_travis_ci' : 'Chrome'],
 
         // If browser does not capture in given timeout [ms], kill it
         // CLI --capture-timeout 5000

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 'use strict';
 
+var headlessBrowsers = [
+    'Chrome',
+    'Chromium',
+    'ChromeCanary',
+    'Firefox',
+    'FirefoxDeveloper',
+    'FirefoxAurora',
+    'FirefoxNightly',
+];
+
 var DetectBrowsers = function (config, logger) {
     var fs = require('fs'),
         os = require('os'),
@@ -31,10 +41,18 @@ var DetectBrowsers = function (config, logger) {
                 browserPaths = browser.DEFAULT_CMD[process.platform] || [],
                 y, paths = browserPaths.length;
 
+            if (process.env[browser.ENV_CMD]) {
+                log.info('which.sync(process.env[browser.ENV_CMD]): ', which.sync(process.env[browser.ENV_CMD]));
+            }
+            if (process.env[browser.ENV_CMD] && which.sync(process.env[browser.ENV_CMD])) {
+                result.push(browser.name);
+                continue;
+            }
+
             // iterate over all browser paths
             for (y = 0; y < paths; y++) {
                 try {
-                    var browserLocated = fs.existsSync(browserPaths[y]) || process.env[browser.ENV_CMD] || which.sync(browserPaths[y]);
+                    var browserLocated = fs.existsSync(browserPaths[y]) || which.sync(browserPaths[y]);
 
                     // don't use Edge on operating systems other than Windows 10
                     // (the launcher would be found, but would fail to run)
@@ -45,7 +63,7 @@ var DetectBrowsers = function (config, logger) {
                         result.push(browser.name);
 
                         // set env variable on win32 when it does not exist yet
-                        if (process.platform === 'win32' && !process.env[browser.ENV_CMD]) {
+                        if (process.platform === 'win32') {
                             process.env[browser.ENV_CMD] = browserPaths[y];
                         }
 
@@ -67,8 +85,13 @@ var DetectBrowsers = function (config, logger) {
         log.info('Detecting browsers is disabled. The browsers of the browsers array are used.');
         return;
     }
-
     var availableBrowser = getInstalledBrowsers(browsers);
+
+    if (config.detectBrowsers.preferHeadless) {
+        availableBrowser = availableBrowser.map(function (browser) {
+            return headlessBrowsers.indexOf(browser) >= 0 ? browser + 'Headless' : browser;
+        });
+    }
 
     // override the browsers in the config only when browsers where find by this plugin
     if (availableBrowser.length >= 0) {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-jshint": "^1.1.0",
         "grunt-karma": "^2.0.0",
-        "jasmine-core": "^2.4.1",
-        "karma": "^1.7.0",
+        "jasmine-core": "^3.1.0",
+        "karma": "^2.0.0",
         "karma-chrome-launcher": "*",
         "karma-edge-launcher": "*",
         "karma-firefox-launcher": "*",
@@ -86,7 +86,7 @@
         "karma-phantomjs-launcher": "*",
         "karma-safari-launcher": "*",
         "karma-safaritechpreview-launcher": "*",
-        "phantomjs-prebuilt": "2.1.14"
+        "phantomjs-prebuilt": "2.1.16"
     },
     "dependencies": {
         "which": "^1.2.4"


### PR DESCRIPTION
Chromium is resolved in this order:

1. Puppeteer installed locally
2. Puppeteer installed globally
3. System installed Chromium