### PR TITLE
Cross checking available browsers against configured loaders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module.exports = function(config) {
 
       // post processing of browsers list
       // here you can edit the list of browsers used by karma
-      postDetection: function(availableBrowser) {
+      postDetection: function(availableBrowsers) {
         /* Karma configuration with custom launchers
           customLaunchers: {
             IE9: {
@@ -82,14 +82,14 @@ module.exports = function(config) {
         */
 
           //Add IE Emulation
-          var result = availableBrowser;
+          var result = availableBrowsers;
 
-          if (availableBrowser.indexOf('IE')>-1) {
+          if (availableBrowsers.indexOf('IE')>-1) {
             result.push('IE9');
           }
 
           //Remove PhantomJS if another browser has been detected
-          if (availableBrowser.length > 1 && availableBrowser.indexOf('PhantomJS')>-1) {
+          if (availableBrowsers.length > 1 && availableBrowsers.indexOf('PhantomJS')>-1) {
             var i = result.indexOf('PhantomJS');
 
             if (i !== -1) {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ var DetectBrowsers = function (config, logger) {
         log.info('Detecting browsers is disabled. The browsers of the browsers array are used.');
         return;
     }
-    const configuredLaunchers = config.plugins.reduce((prev, plugin) => {
+    var configuredLaunchers = config.plugins.reduce((prev, plugin) => {
         return prev.concat(Object.keys(plugin).filter(key => key.startsWith('launcher:')));
     }, []);
 
@@ -101,7 +101,7 @@ var DetectBrowsers = function (config, logger) {
     log.info('The following browsers were detected on your system:', availableBrowsers);
 
     availableBrowsers = availableBrowsers.reduce((aggregate, browser) => {
-        if (configuredLaunchers.includes('launcher:' + browser)) {
+        if (configuredLaunchers.indexOf('launcher:' + browser) >= 0) {
             return aggregate.concat(browser);
         }
         log.warn('No launcher found for browser ' + browser + ', it will not be used.');
@@ -122,7 +122,7 @@ var DetectBrowsers = function (config, logger) {
             availableBrowsers = config.detectBrowsers.postDetection(availableBrowsers);
         }
 
-        const browsers = config.browsers || [];
+        var browsers = config.browsers || [];
         if (availableBrowsers.length > 0) {
             config.browsers = browsers.concat(
                 availableBrowsers.filter(function (browser) {


### PR DESCRIPTION
Avoids the `Cannot load browser "${browser": it is not registered! Perhaps you are missing some plugin?` errors.