### PR TITLE
Fixing chromium path for MacOS

### DIFF
--- a/browsers/Chromium.js
+++ b/browsers/Chromium.js
@@ -8,7 +8,7 @@ module.exports = {
             'chromium',
         ],
         darwin: [
-            '/Applications/Google Chrome.app/Contents/MacOS/Chromium',
+            '/Applications/Chromium.app/Contents/MacOS/Chromium',
         ],
         win32: [
             process.env['ProgramFiles(x86)'] + '\\Chromium\\Application\\chrome.exe',


### PR DESCRIPTION
Not sure how I missed this, but the Chromium path is wrong for MacOS