### PR TITLE
Detect Chromium Edge with the plugin @chiragrupani/karma-chromium-edge-launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = function(config) {
 
     plugins: [
       'karma-chrome-launcher',
-      'karma-edge-launcher',
+      '@chiragrupani/karma-chromium-edge-launcher',
       'karma-firefox-launcher',
       'karma-ie-launcher',
       'karma-safari-launcher',
@@ -103,7 +103,7 @@ module.exports = function(config) {
 
     plugins: [
       'karma-chrome-launcher',
-      'karma-edge-launcher',
+      '@chiragrupani/karma-chromium-edge-launcher',
       'karma-firefox-launcher',
       'karma-ie-launcher',
       'karma-safari-launcher',

--- a/browsers/Edge.js
+++ b/browsers/Edge.js
@@ -1,15 +1,29 @@
-var CMD;
+var linux, darwin, win32;
 
 try {
-    CMD = require.resolve('edge-launcher/dist/x86/MicrosoftEdgeLauncher.exe');
-} catch (e) {
-    CMD = '';
+    var ChromiumEdge = require('@chiragrupani/karma-chromium-edge-launcher')['launcher:Edge'][1].prototype.DEFAULT_CMD;
+} catch (ignore) {}
+
+try {
+    var ChromiumEdge = require('karma-chromium-edge-launcher')['launcher:Edge'][1].prototype.DEFAULT_CMD;
+} catch (ignore) {}
+
+if (ChromiumEdge) {
+    linux = ChromiumEdge.linux;
+    darwin = ChromiumEdge.darwin;
+    win32 = ChromiumEdge.win32;
+} else {
+    try {
+        win32 = require.resolve('edge-launcher/dist/x86/MicrosoftEdgeLauncher.exe');
+    } catch (ignore) {}
 }
 
 module.exports = {
     name: 'Edge',
     DEFAULT_CMD: {
-        win32: [CMD]
+        linux: [linux || ''],
+        darwin: [darwin || ''],
+        win32: [win32 || '']
     },
     ENV_CMD: 'EDGE_BIN'
 };

--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -61,7 +61,7 @@ module.exports = function (config) {
         plugins: [
             'karma-jasmine',
             'karma-chrome-launcher',
-            'karma-edge-launcher',
+            '@chiragrupani/karma-chromium-edge-launcher',
             'karma-firefox-launcher',
             'karma-ie-launcher',
             'karma-safari-launcher',


### PR DESCRIPTION
As we knew Microsoft has used a new Edge based on Chromium by default, and I want your plugin to try to detect via the plugin [@chiragrupani/karma-chromium-edge-launcher](https://github.com/ChiragRupani/karma-chromiumedge-launcher) according to https://github.com/karma-runner/karma-edge-launcher/issues/11.

At the same time, it may be a better way for compatibility when integrating this plugin with `karma-edge-launcher`.