### PR TITLE
Detect new Firefox binary files in MacOS

### DIFF
--- a/browsers/Firefox.js
+++ b/browsers/Firefox.js
@@ -2,7 +2,10 @@ module.exports = {
     name: 'Firefox',
     DEFAULT_CMD: {
         linux: ['firefox'],
-        darwin: ['/Applications/Firefox.app/Contents/MacOS/firefox-bin'],
+        darwin: [
+            '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
+            '/Applications/Firefox.app/Contents/MacOS/firefox'
+        ],
         win32: [
             process.env.LOCALAPPDATA + '\\Mozilla Firefox\\firefox.exe',
             process.env.ProgramW6432 + '\\Mozilla Firefox\\firefox.exe',


### PR DESCRIPTION
The Firefox new binary file has been renamed to `firefox` in MacOS.